### PR TITLE
fix(useMaskEditor): retint preserves only pure-white pixels, not any pixel with red=255

### DIFF
--- a/src/hooks/__tests__/useMaskEditor.maskColor.test.tsx
+++ b/src/hooks/__tests__/useMaskEditor.maskColor.test.tsx
@@ -1,0 +1,128 @@
+import { render, waitFor } from '@testing-library/react';
+import { Image as NodeImage } from 'canvas';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { MaskEditor, MaskEditorCanvasRef } from '../../components/MaskEditor';
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserverShim {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as any).ResizeObserver = ResizeObserverShim;
+}
+
+(globalThis as any).Image = NodeImage;
+(window as any).Image = NodeImage;
+
+function createImageDataUrl(width: number, height: number, fill = '#cccccc') {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = fill;
+  ctx.fillRect(0, 0, width, height);
+  return canvas.toDataURL('image/png');
+}
+
+describe('useMaskEditor - maskColor retint', () => {
+  it('retints non-white painted pixels when maskColor changes', async () => {
+    const src = createImageDataUrl(32, 32);
+    const canvasRef = React.createRef<MaskEditorCanvasRef>();
+
+    const { rerender } = render(
+      <MaskEditor
+        src={src}
+        maskColor="#ff0000"
+        onDrawingChange={() => {}}
+        canvasRef={canvasRef}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        const c = canvasRef.current?.maskCanvas;
+        expect(c).toBeTruthy();
+        expect(c!.width).toBeGreaterThan(0);
+      },
+      { timeout: 2000 },
+    );
+
+    const maskCanvas = canvasRef.current!.maskCanvas!;
+    const ctx = maskCanvas.getContext('2d')!;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(10, 10, 1, 1);
+
+    const before = ctx.getImageData(10, 10, 1, 1).data;
+    expect([before[0], before[1], before[2]]).toEqual([255, 0, 0]);
+
+    rerender(
+      <MaskEditor
+        src={src}
+        maskColor="#00ff00"
+        onDrawingChange={() => {}}
+        canvasRef={canvasRef}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        const after = ctx.getImageData(10, 10, 1, 1).data;
+        expect([after[0], after[1], after[2]]).toEqual([0, 255, 0]);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('preserves pure-white erase marks across maskColor changes', async () => {
+    const src = createImageDataUrl(32, 32);
+    const canvasRef = React.createRef<MaskEditorCanvasRef>();
+
+    const { rerender } = render(
+      <MaskEditor
+        src={src}
+        maskColor="#ff0000"
+        onDrawingChange={() => {}}
+        canvasRef={canvasRef}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        const c = canvasRef.current?.maskCanvas;
+        expect(c).toBeTruthy();
+        expect(c!.width).toBeGreaterThan(0);
+      },
+      { timeout: 2000 },
+    );
+
+    const maskCanvas = canvasRef.current!.maskCanvas!;
+    const ctx = maskCanvas.getContext('2d')!;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(5, 5, 4, 4);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(20, 20, 4, 4);
+
+    rerender(
+      <MaskEditor
+        src={src}
+        maskColor="#00ff00"
+        onDrawingChange={() => {}}
+        canvasRef={canvasRef}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        const painted = ctx.getImageData(6, 6, 1, 1).data;
+        expect([painted[0], painted[1], painted[2]]).toEqual([0, 255, 0]);
+      },
+      { timeout: 2000 },
+    );
+
+    const erased = ctx.getImageData(21, 21, 1, 1).data;
+    expect([erased[0], erased[1], erased[2]]).toEqual([255, 255, 255]);
+  });
+});

--- a/src/hooks/useMaskEditor.ts
+++ b/src/hooks/useMaskEditor.ts
@@ -666,8 +666,11 @@ export function useMaskEditor(props: UseMaskEditorProps): UseMaskEditorReturn {
       const color = hexToRgb(hexColor);
       if (imageData && color) {
         for (let i = 0; i < imageData.data.length; i += 4) {
-          const pixelColor =
-            (imageData.data[i] === 255) != invert ? [255, 255, 255] : color;
+          const isPureWhite =
+            imageData.data[i] === 255 &&
+            imageData.data[i + 1] === 255 &&
+            imageData.data[i + 2] === 255;
+          const pixelColor = isPureWhite != invert ? [255, 255, 255] : color;
           imageData.data[i] = pixelColor[0];
           imageData.data[i + 1] = pixelColor[1];
           imageData.data[i + 2] = pixelColor[2];


### PR DESCRIPTION
## Problem

Setting `maskColor` to `#ff0000`, painting a stroke, then changing `maskColor` to `#00ff00` turns the existing stroke **white** instead of green. Same thing happens going from the default `#ffffff` to any other color; strokes never retint away from white.

## Cause

`useMaskEditor`'s `replaceMaskColor` runs on every `maskColor` change and walks the mask canvas pixel by pixel. It tries to preserve pure-white pixels (the color used by the shift/right-click erase path) and retint everything else, but the "is white" test only checks the red channel:

```ts
// src/hooks/useMaskEditor.ts
const pixelColor =
  (imageData.data[i] === 255) != invert ? [255, 255, 255] : color;
```

`data[i] === 255` is true for any color with `R=255` — `#ff0000`, `#ffff00`, `#ff00ff`, `#ffffff`, etc so all of those collapse to white on retint instead of being treated as paint.

## Fix

Check all three channels:

```ts
const isPureWhite =
  imageData.data[i]     === 255 &&
  imageData.data[i + 1] === 255 &&
  imageData.data[i + 2] === 255;
const pixelColor = isPureWhite != invert ? [255, 255, 255] : color;
```

Pure-white erase marks are still preserved. Strokes in any other color retint as expected.

## Tests

Added `src/hooks/__tests__/useMaskEditor.maskColor.test.tsx` with two cases:

1. Paint a red pixel, change `maskColor` from `#ff0000` to `#00ff00`, assert pixel is `[0, 255, 0]`. Fails on `main`, passes with the fix.
2. Paint a red pixel **and** a pure-white pixel, change `maskColor`, assert red retints to green and pure-white stays white.

> **Note on test infrastructure:** the existing `useMaskEditor.initialMask.test.tsx` already does not run on a clean install — `jsdom` and `canvas` are not in `package.json`, and `setupTests.ts` is missing a `ResizeObserver` polyfill. The new test needs the same things. To run it locally:
>
> ```sh
> npm install --no-save jsdom canvas
> npx vitest run src/hooks/__tests__/useMaskEditor.maskColor.test.tsx
> ```
>
> Fixing the test infra is out of scope for this PR.

## Reproduce the bug (manual, no install needed)

In any Storybook story (e.g. **Mask Editor / Default**) on `main`:

1. Set the `maskColor` control to `#ff0000`.
2. Paint a stroke on the image.
3. Change the `maskColor` control to `#00ff00`.
4. **Bug:** the existing red stroke turns white instead of green.
5. Apply this PR and repeat — the stroke now correctly becomes green.

Repeat with starting color `#ffffff` (default) → any other color for the same effect. Starting color `#0000ff` already retints correctly (red channel is 0), serving as a regression check.

To verify the erase-path preservation: shift-click (or right-click) to paint a white "erase" mark, then change `maskColor`. The white mark should stay white in both before and after the fix.

## Minimal repro snippet

```tsx
const [color, setColor] = useState('#ff0000');
return (
  <>
    <MaskEditor src="/some-image.jpg" maskColor={color} onDrawingChange={() => {}} />
    <button onClick={() => setColor('#00ff00')}>Switch to green</button>
  </>
);
```

Paint a stroke before clicking the button.

## Follow-ups (not in this PR)

- The `invert` parameter on `replaceMaskColor` is dead; the only call site passes `false`. Worth removing in a separate PR.
- `hexToRgb` in `src/utils.ts` doesn't accept `#fff` shorthand.
- `setupTests.ts` is missing a `ResizeObserver` polyfill, and `jsdom` / `canvas` are not declared in `package.json`, so the existing test suite won't run on a clean install.
